### PR TITLE
Update CI to build for Node.js 24 and latest only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,35 +16,27 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [24.x, latest]
 
-    runs-on: ${{ matrix.os }} 
-        
+    runs-on: ${{ matrix.os }}
+
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm i
     - run: npm run build --if-present
-
-    - name: test22
-      if: matrix['node-version'] == '22.x'
-      run: npm run test22
-
-    - name: test
-      if: matrix['node-version'] == '20.x' || matrix['node-version'] == '18.x'
-      run: npm run test
+    - run: npm test
 
     - name: test-cov
-      if: matrix['node-version'] == '22.x' && matrix['os'] == 'ubuntu-latest'
+      if: matrix['node-version'] == '24.x' && matrix['os'] == 'ubuntu-latest'
       run: npm run test-cov
-      
+
     - name: coveralls
-      if: matrix['node-version'] == '22.x' && matrix['os'] == 'ubuntu-latest'
+      if: matrix['node-version'] == '24.x' && matrix['os'] == 'ubuntu-latest'
       uses: coverallsapp/github-action@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         path-to-lcov: ./coverage/lcov.info
-


### PR DESCRIPTION
- Replace node 18/20/22 matrix with 24.x and latest
- Remove obsolete test22 step (script no longer exists)
- Use single `npm test` step for all versions
- Update actions/checkout and actions/setup-node to v4

https://claude.ai/code/session_015pFjG7ghbYrAiF5g9nfVcM