### PR TITLE
Update Go jsonic/directive/path to main branches for Plugin error return

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -3,7 +3,7 @@ module github.com/jsonicjs/multisource/go
 go 1.24.7
 
 require (
-	github.com/jsonicjs/directive/go v0.1.0
-	github.com/jsonicjs/jsonic/go v0.1.6
-	github.com/jsonicjs/path/go v0.1.0
+	github.com/jsonicjs/directive/go v0.1.2-0.20260418140749-9355df887eff
+	github.com/jsonicjs/jsonic/go v0.1.19-0.20260418131021-ec70f537dda6
+	github.com/jsonicjs/path/go v0.1.1-0.20260418140640-6d7812fba3ee
 )

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,8 +1,6 @@
-github.com/jsonicjs/directive/go v0.1.0 h1:ajPq4SJ/iShncaO+rMVSpNEMKbQhZxMGUxRkf42epyY=
-github.com/jsonicjs/directive/go v0.1.0/go.mod h1:QSlUJcNs1/hhJzjKdRu/iz+QQp2YRJtzFRcD6/0llGY=
-github.com/jsonicjs/jsonic/go v0.1.4 h1:V1KEzmg/jIwk25+JYj8ig1+B7190rHmH8WqZbT7XlgA=
-github.com/jsonicjs/jsonic/go v0.1.4/go.mod h1:ObNKlCG7esWoi4AHCpdgkILvPINV8bpvkbCd4llGGUg=
-github.com/jsonicjs/jsonic/go v0.1.6 h1:oUw4vxCK6tqa7SGN87vjCtx3sCpeHXdqfl25hx5LKP0=
-github.com/jsonicjs/jsonic/go v0.1.6/go.mod h1:ObNKlCG7esWoi4AHCpdgkILvPINV8bpvkbCd4llGGUg=
-github.com/jsonicjs/path/go v0.1.0 h1:rByeAJ/Zd/1q9WzI3VOQjW3axIvHr+o4lUEodUYhKx4=
-github.com/jsonicjs/path/go v0.1.0/go.mod h1:/LLj1pxpn/e0Xu3Oo91YzGL5owcPasKfICNDGHY8GEM=
+github.com/jsonicjs/directive/go v0.1.2-0.20260418140749-9355df887eff h1:7dsCMlacsKU67IxjR3YA8WdswzbJgfWXG+dSyFVtKTI=
+github.com/jsonicjs/directive/go v0.1.2-0.20260418140749-9355df887eff/go.mod h1:8vStmea7Om9NrI205Rs3JkaRk9BluWl5xsJeubNA2tY=
+github.com/jsonicjs/jsonic/go v0.1.19-0.20260418131021-ec70f537dda6 h1:ir3VMZHrFbCGqj/LcBadgB4VVsa13UkCOXUeV6fDkGw=
+github.com/jsonicjs/jsonic/go v0.1.19-0.20260418131021-ec70f537dda6/go.mod h1:ObNKlCG7esWoi4AHCpdgkILvPINV8bpvkbCd4llGGUg=
+github.com/jsonicjs/path/go v0.1.1-0.20260418140640-6d7812fba3ee h1:bnRpKmv8S5++wV0THiLw4gFBS84eDTfeBOBsD5c19Sk=
+github.com/jsonicjs/path/go v0.1.1-0.20260418140640-6d7812fba3ee/go.mod h1:oVOtn7SlkYtff2EwQn7L6nV0SvXmjocOqxxmNOCvKj8=

--- a/go/plugin.go
+++ b/go/plugin.go
@@ -12,7 +12,7 @@ import (
 // MultiSource is a jsonic plugin that adds multisource reference support.
 // When '@path' is encountered in the input, the path is resolved using
 // the configured resolver and processed into a value.
-func MultiSource(j *jsonic.Jsonic, pluginOpts map[string]any) {
+func MultiSource(j *jsonic.Jsonic, pluginOpts map[string]any) error {
 	opts := getOpts(pluginOpts)
 	markChar := opts.MarkChar
 	if markChar == "" {
@@ -136,6 +136,7 @@ func MultiSource(j *jsonic.Jsonic, pluginOpts map[string]any) {
 	}
 
 	directive.Apply(j, dopts)
+	return nil
 }
 
 // resolveSource resolves a multisource path and returns the processed value.


### PR DESCRIPTION
jsonic/go's Plugin type now returns error. Pseudo-versioned to the main
branch of jsonic, directive, and path Go modules, and updated MultiSource
to match the new signature.

https://claude.ai/code/session_01CGPK6Vu6WB56L9EiE4zpBD